### PR TITLE
Override Tomcat version to 10.1.55

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,11 @@
         <java.version>21</java.version>
         <c3p0.version>0.12.0</c3p0.version>
         <mchange-commons-java.version>0.4.0</mchange-commons-java.version>
+        <!-- Temporary override for CVE-2026-41293 and CVE-2026-43512.
+          Remove after the parent com.czertainly:dependencies upgrades to a Spring Boot release that ships Tomcat 10.1.55+
+          (expected with Spring Boot 3.5.15). Then delete this override. -->
+        <tomcat.version>10.1.55</tomcat.version>
+
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.organization>ilm</sonar.organization>
         <sonar.projectKey>ilm_scheduler</sonar.projectKey>


### PR DESCRIPTION
Add a temporary <tomcat.version> property to pom.xml to pin Tomcat to 10.1.55 as a mitigation for CVE-2026-41293 and CVE-2026-43512.