### PR TITLE
Update parent, dependencies, and GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,22 +12,22 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Set up JDK 21
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           java-version: 21
           distribution: 'temurin'
       - name: Cache SonarQube packages
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
       - name: Cache Maven packages
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/build_pr.yml
+++ b/.github/workflows/build_pr.yml
@@ -14,16 +14,16 @@ jobs:
       packages: read
       security-events: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Set up JDK 21
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           java-version: 21
           distribution: 'temurin'
       - name: Cache Maven packages
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,13 +40,13 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       with:
         fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
+      uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -73,7 +73,7 @@ jobs:
     #     ./location_of_script_within_repo/buildscript.sh
     
     - name: Set up JDK 21
-      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+      uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
       with:
         java-version: 21
         distribution: 'temurin'
@@ -81,7 +81,7 @@ jobs:
         server-username: GITHUB_USER_REF
         server-password: GITHUB_TOKEN_REF
     - name: Cache Maven packages
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
@@ -94,6 +94,6 @@ jobs:
       run: mvn -B -U verify
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
+      uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -42,7 +42,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # Checkout the PR branch
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           repository: ${{ github.event.workflow_run.head_repository.full_name }}
           ref: ${{ github.event.workflow_run.head_branch }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM maven:3.9.14-eclipse-temurin-21 AS build
+FROM maven:3.9.16-eclipse-temurin-21 AS build
 COPY src /home/app/src
 COPY pom.xml /home/app
 COPY settings.xml /root/.m2/settings.xml

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,9 @@ FROM eclipse-temurin:21-jre-alpine
 
 LABEL org.opencontainers.image.authors="ILM <support@otilm.com>"
 
+# apply outstanding Alpine security updates on top of the base image
+RUN apk --no-cache upgrade
+
 # add non root user otilm
 RUN addgroup --system --gid 10001 otilm && adduser --system --home /opt/otilm --uid 10001 --ingroup otilm otilm
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.otilm</groupId>
         <artifactId>dependencies</artifactId>
-        <version>1.4.1</version>
+        <version>1.4.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>scheduler</artifactId>
@@ -16,12 +16,8 @@
 
     <properties>
         <java.version>21</java.version>
-        <c3p0.version>0.12.0</c3p0.version>
-        <mchange-commons-java.version>0.4.0</mchange-commons-java.version>
-        <!-- Temporary override for CVE-2026-41293 and CVE-2026-43512.
-          Remove after the parent com.otilm:dependencies upgrades to a Spring Boot release that ships Tomcat 10.1.55+
-          (expected with Spring Boot 3.5.15). Then delete this override. -->
-        <tomcat.version>10.1.55</tomcat.version>
+        <c3p0.version>0.14.1</c3p0.version>
+        <mchange-commons-java.version>0.6.1</mchange-commons-java.version>
 
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.organization>ilm</sonar.organization>
@@ -76,14 +72,14 @@
         <dependency>
             <groupId>org.apache.qpid</groupId>
             <artifactId>qpid-jms-client</artifactId>
-            <version>2.9.0</version>
+            <version>2.10.0</version>
         </dependency>
 
         <!-- Azure Identity for AAD authentication -->
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-identity</artifactId>
-            <version>1.18.3</version>
+            <version>1.18.4</version>
         </dependency>
 
         <!-- JMS connection pooling -->

--- a/settings.xml
+++ b/settings.xml
@@ -3,22 +3,6 @@
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
 
-    <activeProfiles>
-        <activeProfile>github</activeProfile>
-    </activeProfiles>
-
-    <profiles>
-        <profile>
-            <id>github</id>
-            <repositories>
-                <repository>
-                    <id>ossrh-releases</id>
-                    <url>https://s01.oss.sonatype.org/content/repositories/releases</url>
-                </repository>
-            </repositories>
-        </profile>
-    </profiles>
-
     <servers>
         <server>
             <id>github</id>


### PR DESCRIPTION
## Summary

Bump the parent POM to the current `com.otilm:dependencies` SNAPSHOT, remove the now-redundant Tomcat override, and fold in the dependency, GitHub Actions, and container updates that are safe to ship together. Two CI-blocking build issues surfaced along the way and are fixed here as well.

## Parent and Tomcat override

- Parent `com.otilm:dependencies` `1.4.1` → `1.4.2-SNAPSHOT`, which moves the managed set to Spring Boot 3.5.16.
- Removed the temporary `tomcat.version` override. Spring Boot 3.5.16 manages Tomcat `10.1.55` itself, so the pin no longer changes the resolved version and only adds drift risk. CVE-2026-41293 and CVE-2026-43512 remain covered by the parent-managed version.

Verified after the change:

```
mvn help:evaluate -Dexpression=tomcat.version  ->  10.1.55
tomcat-embed-core / -el / -websocket           ->  10.1.55 (from spring-boot-starter-tomcat 3.5.16)
```

## Dependency updates

| Dependency | Old | New | Rationale |
|---|---|---|---|
| `com.mchange:c3p0` | 0.12.0 | 0.14.1 | Fixes CVE-2026-55223 / GHSA-w6w4-rjh9-9r58 (CVSS 6.3). c3p0 `DataSource` exposed `getConnection()` and `getPooledConnection()` as JavaBean properties, making it a sink for deserialization gadget chains. The fix adds explicit `BeanInfo` classes; no API change. |
| `com.mchange:mchange-commons-java` | 0.4.0 | 0.6.1 | Coupled to the above — c3p0 0.14.1 declares mchange-commons-java 0.6.1. Keeping the 0.4.0 pin would downgrade c3p0's own transitive dependency. |
| `org.apache.qpid:qpid-jms-client` | 2.9.0 | 2.10.0 | Minor bump with an identical transitive dependency set (proton-j, netty, opentracing). |
| `com.azure:azure-identity` | 1.18.3 | 1.18.4 | Patch bump. |

`com.otilm:interfaces` stays at `2.18.1-SNAPSHOT` — already the current `main` version.

**The parent bump clears the image's Java vulnerabilities.** Trivy on `main` reports 25 HIGH advisories in `app.jar`, including jackson-databind 2.21.3 (CVE-2026-54512, CVE-2026-54513). On this branch that count is zero: the new parent brings jackson 2.22.1, netty 4.1.136.Final, and postgresql 42.7.12.

## GitHub Actions

All actions remain pinned to full commit SHAs.

| Action | Previous | Updated to | Change |
|---|---|---|---|
| `actions/checkout` | `de0fac…83dd # v6.0.2` | `d23441…f803 # v6.1.0` | Updated |
| `actions/setup-java` | `be666c…6654 # v5.2.0` | `03ad4d…ac95 # v5.6.0` | Updated |
| `actions/cache` | `27d5ce…ccae # v5.0.5` | `55cc83…52a9 # v6.1.0` | Major update (v6.0.0 is an ESM migration only) |
| `github/codeql-action` | `95e58e…d225 # v4.35.2` | `f205ea…7b38 # v4.37.4` | Updated |

Already on the latest release: `actions/upload-artifact` v7.0.1, `actions/download-artifact` v8.0.1, `octokit/request-action` v3.0.0. The `OmniTrustILM/.github` reusable workflows stay on `@main` by convention.

**`actions/checkout` v7.0.1 was deliberately skipped.** v7.0.0 blocks checking out a fork PR head under `pull_request_target` and `workflow_run`, and `.github/workflows/sonar.yaml` does exactly that (`repository: ${{ github.event.workflow_run.head_repository.full_name }}`). Staying on the latest v6.

## Container and build fixes

- Build stage: `maven:3.9.14-eclipse-temurin-21` → `maven:3.9.16-eclipse-temurin-21`, the current 3.9.x tag. Supersedes #87.
- **Dropped the decommissioned OSSRH repository from `settings.xml`.** The Dockerfile installs this file as the build stage's `/root/.m2/settings.xml`, and it declared `s01.oss.sonatype.org` as an active repository. Sonatype retired that host; it now answers with a redirect or 403 instead of artifacts. That made image builds non-deterministic — on this branch the amd64 leg failed to resolve `spring-boot-starter-parent:3.5.16` through the dead host while the arm64 leg, on the same commit, resolved it from Maven Central and built cleanly. Maven Central, GitHub Packages, and the Central Portal snapshot repository already cover everything the build needs.
- **Added `apk --no-cache upgrade` to the runtime stage.** Trivy fails on four HIGH OS-package advisories carried by `eclipse-temurin:21-jre-alpine`: CVE-2026-56131 and CVE-2026-56408 (libexpat 2.8.1-r0) and CVE-2026-2100 (p11-kit 0.25.5-r2). Fixed Alpine packages exist, but the base tag has not been rebuilt since 2026-06-22. The trade-off is that package contents now depend on build date as well as the base tag.

Both of these were already failing on `main` — #108, which touches neither `pom.xml` nor the Dockerfile, fails the same two Docker jobs.

The runtime stage stays on `eclipse-temurin:21-jre-alpine`. #62 proposes Temurin 25, a JRE major bump against a Java 21 target, which belongs in its own PR.

## Verification

`mvn -B verify` passes locally: 70 tests, 0 failures, 0 errors, BUILD SUCCESS.

## Review comments

- Copilot flagged the `steps:` indentation in `codeql.yml` as invalid YAML. It is valid — a block sequence may sit at the same indentation as its owning mapping key — and the `Analyze (java)` check passes on this PR. No change made.
- SonarCloud flagged the fork checkout in `sonar.yaml`. Genuine and worth acting on, but pre-existing and unchanged by this PR; it entered the diff only because the `uses:` pin on that line moved. See the thread for detail and follow-up options.

## Follow-ups

- The parent is a SNAPSHOT. It must be pinned to a released `1.4.2` before the next scheduler release — `dependencies` `main` is currently 4 commits past the `1.4.1` tag.
- The `Sonar` workflow runs fork code with `SONAR_TOKEN` in scope on a public repository. Needs its own fix; `actions/checkout` v7 is the natural companion once it lands.
- `settings.xml` still carries an empty `<server id="github">` while the Dockerfile declares unused `SERVER_USERNAME` / `SERVER_PASSWORD` build args, which is why GitHub Packages returns 401 during image builds. Harmless today because the Central Portal snapshot repository serves the SNAPSHOT artifacts, but it is dead wiring.
- Superseded bot PRs to close once this merges: #76, #87, #89, #91, #95, #96, #99, #103, #105, #107.
- #108 (`chore/sync-to-org-template`) also touches the workflow files; expect a conflict depending on merge order.