### PR TITLE
Adopt the shared Java formatting gates

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,105 @@
+# EditorConfig — IDE-level enforcement of line endings, indentation and the full
+# Java code style. https://editorconfig.org  (IntelliJ has built-in support; no
+# plugin required, and it takes precedence over the IDE's own code style scheme.)
+# This is the IDE's first line of defence; Spotless (mvn verify) is the authoritative gate.
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.java]
+indent_style = space
+indent_size = 4
+continuation_indent_size = 8
+max_line_length = 120
+
+# Never auto-wrap while typing; Spotless owns final wrapping.
+ij_wrap_on_typing = false
+
+# Imports. Never collapse to a wildcard (Checkstyle AvoidStarImport forbids it and
+# Spotless cannot expand one back). Layout is IntelliJ's default and mirrors
+# eclipse.importorder (0= / 1=\#): one alphabetical block, blank line, static last.
+ij_java_class_count_to_use_import_on_demand = 999
+ij_java_names_count_to_use_import_on_demand = 999
+ij_java_imports_layout = *,|,$*
+
+# Javadoc. Eclipse puts a single space before a tag description and never pads to
+# align, nor adds <p> to empty lines.
+ij_java_doc_align_param_comments = false
+ij_java_doc_align_exception_comments = false
+ij_java_doc_add_p_tag_on_empty_lines = false
+
+# Blank lines. Eclipse has ONE knob for this (number_of_empty_lines_to_preserve=1);
+# IntelliJ splits it into three, and the two added below default to 2 — omit them
+# and a second blank line between members survives the IDE only for Spotless to
+# collapse it, which is exactly the round-trip drift this file exists to prevent.
+# The key is ..._before_rbrace, NOT ..._before_right_brace: a misspelled ij_*
+# property is silently ignored, so a typo here fails open and undetected.
+ij_java_keep_blank_lines_in_code = 1
+ij_java_keep_blank_lines_in_declarations = 1
+ij_java_keep_blank_lines_before_rbrace = 1
+ij_java_blank_lines_after_class_header = 0
+ij_java_blank_lines_around_method = 1
+ij_java_blank_lines_around_field = 0
+
+# Eclipse always breaks a controlled statement onto its own line and never
+# collapses a simple block, method, lambda or class.
+ij_java_keep_control_statement_in_one_line = false
+ij_java_keep_simple_methods_in_one_line = false
+ij_java_keep_simple_lambdas_in_one_line = false
+ij_java_keep_simple_blocks_in_one_line = false
+ij_java_keep_simple_classes_in_one_line = false
+
+# Wrap per construct only when the line exceeds the margin ("normal" = wrap if
+# long). Do NOT set ij_java_wrap_long_lines = true: it force-breaks long
+# annotations and string literals that Eclipse leaves intact.
+ij_java_wrap_long_lines = false
+ij_java_method_parameters_wrap = normal
+ij_java_call_parameters_wrap = normal
+ij_java_throws_list_wrap = normal
+ij_java_throws_keyword_wrap = normal
+ij_java_binary_operation_wrap = normal
+ij_java_ternary_operation_wrap = normal
+ij_java_assignment_wrap = normal
+ij_java_array_initializer_wrap = normal
+ij_java_extends_list_wrap = normal
+# One call per line, but only for a chain that does not fit. Mirrors Eclipse's
+# alignment_for_selector_in_method_invocation=48.
+ij_java_method_call_chain_wrap = on_every_item
+
+# Eclipse indents every continuation by a flat 8 spaces; IntelliJ aligns to the
+# opening delimiter instead. Continuation alignment is the single largest source of
+# IDE/build drift, so it is off everywhere below.
+ij_java_align_multiline_parameters = false
+ij_java_align_multiline_parameters_in_calls = false
+ij_java_align_multiline_method_parentheses = false
+ij_java_align_multiline_resources = false
+ij_java_align_multiline_for = false
+ij_java_align_multiline_binary_operation = false
+ij_java_align_multiline_ternary_operation = false
+ij_java_align_multiline_throws_list = false
+ij_java_align_throws_keyword = false
+ij_java_align_multiline_parenthesized_expression = false
+ij_java_align_multiline_array_initializer_expression = false
+ij_java_align_multiline_chained_methods = false
+ij_java_align_multiline_records = false
+
+[*.{xml,yml,yaml,json}]
+indent_style = space
+indent_size = 2
+
+[*.{sh,cmd,bat}]
+indent_style = space
+indent_size = 4
+
+# Batch files are Windows-only and need CRLF, which is what .gitattributes checks
+# them out as. Without this the [*] default above claims LF and the two layers
+# assert opposite things about the same files.
+[*.{cmd,bat}]
+end_of_line = crlf
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,7 @@
+# Commits skipped by `git blame`, so lines are attributed to their real authors.
+#
+# GitHub's blame view honours this file on its own. Locally, the parent POM points
+# `blame.ignoreRevsFile` here on the first Maven build of a clone.
+
+# Apply Spotless formatting, brace and wildcard-import cleanup
+f4d75a9114c9dafc83d1e0214ca6e484f06c41da

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,24 @@
+# Git-level line-ending normalization (last-resort CRLF defence; the IDE .editorconfig
+# is the first layer). Ensures Java and other text sources are stored and checked out
+# with LF regardless of the developer's OS or core.autocrlf setting.
+* text=auto eol=lf
+
+*.java   text eol=lf
+*.xml    text eol=lf
+*.yml    text eol=lf
+*.yaml   text eol=lf
+*.json   text eol=lf
+*.sh     text eol=lf
+*.properties text eol=lf
+
+# Windows-only scripts keep CRLF.
+*.cmd    text eol=crlf
+*.bat    text eol=crlf
+
+# Binaries: never normalize.
+*.jar    binary
+*.png    binary
+*.jpg    binary
+*.gif    binary
+*.p12    binary
+*.jks    binary

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.otilm</groupId>
         <artifactId>dependencies</artifactId>
-        <version>1.4.2</version>
+        <version>1.4.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>scheduler</artifactId>

--- a/src/main/java/com/otilm/scheduler/ExceptionHandlingAdvice.java
+++ b/src/main/java/com/otilm/scheduler/ExceptionHandlingAdvice.java
@@ -1,7 +1,14 @@
 package com.otilm.scheduler;
 
-import com.otilm.api.exception.*;
+import com.otilm.api.exception.AlreadyExistException;
+import com.otilm.api.exception.LocationException;
+import com.otilm.api.exception.NotDeletableException;
+import com.otilm.api.exception.NotFoundException;
+import com.otilm.api.exception.ValidationError;
+import com.otilm.api.exception.ValidationException;
 import com.otilm.api.model.common.ErrorMessageDto;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -9,9 +16,6 @@ import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 @RestControllerAdvice
 public class ExceptionHandlingAdvice {
@@ -65,9 +69,7 @@ public class ExceptionHandlingAdvice {
     public List<String> handleValidationException(ValidationException ex) {
         LOG.info("HTTP 422: {}", ex.getMessage());
 
-        return ex.getErrors().stream()
-                .map(ValidationError::getErrorDescription)
-                .collect(Collectors.toList());
+        return ex.getErrors().stream().map(ValidationError::getErrorDescription).collect(Collectors.toList());
     }
 
     /**
@@ -106,15 +108,15 @@ public class ExceptionHandlingAdvice {
         return ErrorMessageDto.getInstance(ex.getMessage());
     }
 
-//    /**
-//     * Handler for {@link AccessDeniedException}.
-//     */
-//    @ExceptionHandler(AccessDeniedException.class)
-//    public void handleAccessDeniedException(AccessDeniedException ex) {
-//        LOG.warn("Access denied: {}", ex.getMessage());
-//        // re-throw to let the Spring Security handle it
-//        throw ex;
-//    }
+    // /**
+    // * Handler for {@link AccessDeniedException}.
+    // */
+    // @ExceptionHandler(AccessDeniedException.class)
+    // public void handleAccessDeniedException(AccessDeniedException ex) {
+    // LOG.warn("Access denied: {}", ex.getMessage());
+    // // re-throw to let the Spring Security handle it
+    // throw ex;
+    // }
 
     /**
      * Handler for {@link Exception}.

--- a/src/main/java/com/otilm/scheduler/config/SchemaInit.java
+++ b/src/main/java/com/otilm/scheduler/config/SchemaInit.java
@@ -1,5 +1,9 @@
 package com.otilm.scheduler.config;
 
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import javax.sql.DataSource;
 import liquibase.change.DatabaseChange;
 import liquibase.integration.spring.SpringLiquibase;
 import org.slf4j.Logger;
@@ -18,15 +22,10 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.stereotype.Component;
 
-import javax.sql.DataSource;
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.sql.Statement;
-
 @Configuration
-@ConditionalOnClass({ SpringLiquibase.class, DatabaseChange.class })
+@ConditionalOnClass({SpringLiquibase.class, DatabaseChange.class})
 @ConditionalOnProperty(prefix = "spring.liquibase", name = "enabled", matchIfMissing = true)
-@AutoConfigureAfter({ DataSourceAutoConfiguration.class, HibernateJpaAutoConfiguration.class })
+@AutoConfigureAfter({DataSourceAutoConfiguration.class, HibernateJpaAutoConfiguration.class})
 @Import({SchemaInit.SpringLiquibaseDependsOnPostProcessor.class})
 public class SchemaInit {
 
@@ -47,8 +46,7 @@ public class SchemaInit {
 
         @Override
         public void afterPropertiesSet() {
-            try (Connection conn = dataSource.getConnection();
-                 Statement statement = conn.createStatement()) {
+            try (Connection conn = dataSource.getConnection(); Statement statement = conn.createStatement()) {
                 logger.info("Going to create DB schema '{}' if not exists.", schemaName);
                 statement.execute("create schema if not exists " + schemaName);
             } catch (SQLException e) {
@@ -56,7 +54,6 @@ public class SchemaInit {
             }
         }
     }
-
 
     @ConditionalOnBean(SchemaInitBean.class)
     static class SpringLiquibaseDependsOnPostProcessor extends AbstractDependsOnBeanFactoryPostProcessor {

--- a/src/main/java/com/otilm/scheduler/controllers/SchedulerController.java
+++ b/src/main/java/com/otilm/scheduler/controllers/SchedulerController.java
@@ -5,15 +5,20 @@ import com.otilm.api.exception.SchedulerException;
 import com.otilm.api.model.scheduler.SchedulerRequestDto;
 import com.otilm.api.model.scheduler.SchedulerResponseDto;
 import io.swagger.v3.oas.annotations.Parameter;
-import org.springframework.web.bind.annotation.*;
-
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/v1/scheduler")
 public interface SchedulerController {
 
-
-    @RequestMapping(path = "/create", method = RequestMethod.POST, consumes = {"application/json"}, produces = {"application/json"})
+    @RequestMapping(path = "/create", method = RequestMethod.POST, consumes = {"application/json"}, produces = {
+            "application/json"})
     void createNewJob(@RequestBody SchedulerRequestDto schedulerDto) throws SchedulerException;
 
     @GetMapping(path = "/update")
@@ -26,10 +31,10 @@ public interface SchedulerController {
     SchedulerResponseDto listJobs() throws SchedulerException;
 
     @GetMapping(path = "/{jobName}/enable")
-    void enableJob(@Parameter(description = "Job name") @PathVariable String jobName) throws SchedulerException, ConnectorException;
+    void enableJob(@Parameter(description = "Job name") @PathVariable String jobName)
+            throws SchedulerException, ConnectorException;
 
     @GetMapping(path = "/{jobName}/disable")
     void disableJob(@Parameter(description = "Job name") @PathVariable String jobName) throws SchedulerException;
-
 
 }

--- a/src/main/java/com/otilm/scheduler/jobs/SchedulerJob.java
+++ b/src/main/java/com/otilm/scheduler/jobs/SchedulerJob.java
@@ -27,8 +27,12 @@ public class SchedulerJob implements Job {
         final String jobName = jobExecutionContext.getJobDetail().getKey().getName();
         logger.info("SchedulerJob {} was fired.", jobName);
 
-        final String jobClassName = jobExecutionContext.getJobDetail().getJobDataMap().getString(JobConstants.CLASS_TOBE_EXECUTED);
-        final SchedulerJobExecutionMessage schedulerExecutionMessage = new SchedulerJobExecutionMessage(jobName, jobClassName);
+        final String jobClassName = jobExecutionContext
+                .getJobDetail()
+                .getJobDataMap()
+                .getString(JobConstants.CLASS_TOBE_EXECUTED);
+        final SchedulerJobExecutionMessage schedulerExecutionMessage = new SchedulerJobExecutionMessage(jobName,
+                jobClassName);
         messageProducer.sendMessage(schedulerExecutionMessage);
     }
 }

--- a/src/main/java/com/otilm/scheduler/messaging/JmsMessageProducer.java
+++ b/src/main/java/com/otilm/scheduler/messaging/JmsMessageProducer.java
@@ -17,7 +17,8 @@ public class JmsMessageProducer {
     private final MessagePostProcessor messagePostProcessor;
     private final MessagingProperties messagingProperties;
 
-    public JmsMessageProducer(JmsTemplate jmsTemplate, MessagePostProcessor messagePostProcessor, MessagingProperties messagingProperties) {
+    public JmsMessageProducer(JmsTemplate jmsTemplate, MessagePostProcessor messagePostProcessor,
+            MessagingProperties messagingProperties) {
         this.jmsTemplate = jmsTemplate;
         this.messagePostProcessor = messagePostProcessor;
         this.messagingProperties = messagingProperties;

--- a/src/main/java/com/otilm/scheduler/messaging/RoutingKeyMessagePostProcessor.java
+++ b/src/main/java/com/otilm/scheduler/messaging/RoutingKeyMessagePostProcessor.java
@@ -8,9 +8,9 @@ import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Component;
 
 /**
- * A message post-processor that sets the JMS type (routing key) on JMS messages.
- * This class implements the {@link MessagePostProcessor} interface
- * and ensures that the {@code JMSType} header is set on outgoing messages before they are sent.
+ * A message post-processor that sets the JMS type (routing key) on JMS messages. This class implements the
+ * {@link MessagePostProcessor} interface and ensures that the {@code JMSType} header is set on outgoing messages before
+ * they are sent.
  *
  * The routing key value is retrieved from the application configuration using the property
  * {@code spring.messaging.routing-key.scheduler}.

--- a/src/main/java/com/otilm/scheduler/messaging/configuration/AadTokenProvider.java
+++ b/src/main/java/com/otilm/scheduler/messaging/configuration/AadTokenProvider.java
@@ -4,20 +4,18 @@ import com.azure.core.credential.AccessToken;
 import com.azure.core.credential.TokenCredential;
 import com.azure.core.credential.TokenRequestContext;
 import jakarta.jms.Connection;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.net.URI;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.function.BiFunction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Token provider for Azure Active Directory (AAD) authentication with Azure Service Bus.
  * <p>
- * This class implements the Qpid JMS PASSWORD_OVERRIDE extension mechanism to provide
- * OAuth2 tokens for AMQP connections. It caches tokens and automatically refreshes them
- * before expiration.
+ * This class implements the Qpid JMS PASSWORD_OVERRIDE extension mechanism to provide OAuth2 tokens for AMQP
+ * connections. It caches tokens and automatically refreshes them before expiration.
  * </p>
  */
 public class AadTokenProvider implements BiFunction<Connection, URI, Object> {
@@ -54,8 +52,7 @@ public class AadTokenProvider implements BiFunction<Connection, URI, Object> {
     }
 
     private boolean isTokenExpired() {
-        return cachedToken == null
-                || tokenExpiry == null
+        return cachedToken == null || tokenExpiry == null
                 || OffsetDateTime.now().plusMinutes(TOKEN_REFRESH_BUFFER_MINUTES).isAfter(tokenExpiry);
     }
 

--- a/src/main/java/com/otilm/scheduler/messaging/configuration/JmsConfiguration.java
+++ b/src/main/java/com/otilm/scheduler/messaging/configuration/JmsConfiguration.java
@@ -35,8 +35,9 @@ public class JmsConfiguration {
                 && StringUtils.isNotBlank(messagingProperties.virtualHost());
 
         if (hasConfiguredVhost && urlHasAmqpVhost) {
-            logger.warn("BROKER_URL already contains 'amqp.vhost' query parameter; ignoring BROKER_VIRTUAL_HOST={}",
-                    messagingProperties.virtualHost());
+            logger
+                    .warn("BROKER_URL already contains 'amqp.vhost' query parameter; ignoring BROKER_VIRTUAL_HOST={}",
+                            messagingProperties.virtualHost());
         } else if (hasConfiguredVhost) {
             builder.queryParam("amqp.vhost", "vhost:" + messagingProperties.virtualHost());
         }
@@ -59,8 +60,8 @@ public class JmsConfiguration {
     }
 
     /**
-     * Configures authentication for Azure Service Bus.
-     * Supports both AAD (Azure Active Directory) and SAS (Shared Access Signature) authentication.
+     * Configures authentication for Azure Service Bus. Supports both AAD (Azure Active Directory) and SAS (Shared
+     * Access Signature) authentication.
      */
     private void configureServiceBusAuthentication(JmsConnectionFactory factory, MessagingProperties props) {
         if (props.aadAuth() != null && props.aadAuth().isEnabled()) {
@@ -76,10 +77,7 @@ public class JmsConfiguration {
 
             // Special username for OAuth2 token authentication
             factory.setUsername("$jwt");
-            factory.setExtension(
-                    JmsConnectionExtensions.PASSWORD_OVERRIDE.toString(),
-                    tokenProvider
-            );
+            factory.setExtension(JmsConnectionExtensions.PASSWORD_OVERRIDE.toString(), tokenProvider);
         } else {
             // SAS (Shared Access Signature) token authentication
             logger.debug("Configuring Azure Service Bus with SAS authentication");
@@ -90,7 +88,7 @@ public class JmsConfiguration {
 
     @Bean(destroyMethod = "stop")
     public JmsPoolConnectionFactory producerConnectionFactory(ConnectionFactory connectionFactory,
-                                                               MessagingProperties messagingProperties) {
+            MessagingProperties messagingProperties) {
         // JmsPoolConnectionFactory manages connection/session lifecycle independently of
         // Spring's shared-connection mechanism. On connection failure (e.g. amqp:connection:forced),
         // the pool auto-evicts the dead connection and provides a fresh one on the next borrow —
@@ -113,10 +111,11 @@ public class JmsConfiguration {
         pool.setMaxSessionsPerConnection(poolConfig.maxSessionsPerConnection());
         pool.setUseAnonymousProducers(poolConfig.useAnonymousProducers());
         pool.start();
-        logger.info("Started JMS producer connection pool: maxConnections={}, connectionIdleTimeout={}ms, connectionCheckInterval={}ms, maxSessionsPerConnection={}, useAnonymousProducers={}",
-                poolConfig.maxConnections(), poolConfig.connectionIdleTimeout(),
-                poolConfig.connectionCheckInterval(), poolConfig.maxSessionsPerConnection(),
-                poolConfig.useAnonymousProducers());
+        logger
+                .info("Started JMS producer connection pool: maxConnections={}, connectionIdleTimeout={}ms, connectionCheckInterval={}ms, maxSessionsPerConnection={}, useAnonymousProducers={}",
+                        poolConfig.maxConnections(), poolConfig.connectionIdleTimeout(),
+                        poolConfig.connectionCheckInterval(), poolConfig.maxSessionsPerConnection(),
+                        poolConfig.useAnonymousProducers());
         return pool;
     }
 
@@ -130,8 +129,7 @@ public class JmsConfiguration {
 
     @Bean
     public JmsTemplate jmsTemplate(JmsPoolConnectionFactory producerConnectionFactory,
-                                   MessageConverter messageConverter,
-                                   MessagingProperties messagingProperties) {
+            MessageConverter messageConverter, MessagingProperties messagingProperties) {
         JmsTemplate template = new JmsTemplate(producerConnectionFactory);
         template.setMessageConverter(messageConverter);
         if (messagingProperties.brokerType() == MessagingProperties.BrokerType.SERVICEBUS) {

--- a/src/main/java/com/otilm/scheduler/messaging/configuration/MessagingProperties.java
+++ b/src/main/java/com/otilm/scheduler/messaging/configuration/MessagingProperties.java
@@ -11,27 +11,16 @@ import org.springframework.validation.annotation.Validated;
 
 @ConfigurationProperties(prefix = "spring.messaging")
 @Validated
-public record MessagingProperties(
-        @NotNull MessagingProperties.BrokerType brokerType,
-        String brokerUrl,
-        String host,
-        @Min(1) @Max(65535) Integer port,
-        String username,
-        String password,
-        String virtualHost,
-        @NotBlank String exchange,
-        RoutingKey routingKey,
-        @Valid AadAuth aadAuth,
-        Pool pool
-) {
+public record MessagingProperties(@NotNull MessagingProperties.BrokerType brokerType, String brokerUrl, String host,
+        @Min(1) @Max(65535) Integer port, String username, String password, String virtualHost,
+        @NotBlank String exchange, RoutingKey routingKey, @Valid AadAuth aadAuth, Pool pool) {
 
     /**
      * Validates authentication and connection configuration based on broker type.
      */
     public MessagingProperties {
         if (brokerType == null) {
-            throw new IllegalArgumentException(
-                    "BROKER_TYPE must be configured (RABBITMQ or SERVICEBUS)");
+            throw new IllegalArgumentException("BROKER_TYPE must be configured (RABBITMQ or SERVICEBUS)");
         }
         boolean hasUserAndPassword = StringUtils.isNotBlank(username) && StringUtils.isNotBlank(password);
         boolean hasAadAuth = aadAuth != null && aadAuth.isEnabled();
@@ -51,21 +40,20 @@ public record MessagingProperties(
             }
             case SERVICEBUS -> {
                 if (!hasBrokerUrl) {
-                    throw new IllegalArgumentException(
-                            "ServiceBus requires BROKER_URL to be configured");
+                    throw new IllegalArgumentException("ServiceBus requires BROKER_URL to be configured");
                 }
                 if (!hasUserAndPassword && !hasAadAuth) {
                     throw new IllegalArgumentException(
-                            "ServiceBus requires either BROKER_USERNAME/BROKER_PASSWORD (SAS) " +
-                            "or BROKER_AZURE_TENANT_ID/BROKER_AZURE_CLIENT_ID/BROKER_AZURE_CLIENT_SECRET (AAD) to be configured");
+                            "ServiceBus requires either BROKER_USERNAME/BROKER_PASSWORD (SAS) "
+                                    + "or BROKER_AZURE_TENANT_ID/BROKER_AZURE_CLIENT_ID/BROKER_AZURE_CLIENT_SECRET (AAD) to be configured");
                 }
             }
         }
     }
 
     /**
-     * Returns the effective broker URL for connection.
-     * Uses brokerUrl if provided, otherwise constructs from host and port (for RabbitMQ legacy support).
+     * Returns the effective broker URL for connection. Uses brokerUrl if provided, otherwise constructs from host and
+     * port (for RabbitMQ legacy support).
      */
     public String getEffectiveBrokerUrl() {
         if (StringUtils.isNotBlank(brokerUrl)) {
@@ -80,56 +68,51 @@ public record MessagingProperties(
             return exchange();
         }
 
-        String schedulerRoutingKey = (routingKey != null)
-                ? StringUtils.trimToEmpty(routingKey.scheduler())
-                : "";
+        String schedulerRoutingKey = (routingKey != null) ? StringUtils.trimToEmpty(routingKey.scheduler()) : "";
         return "/exchanges/" + exchange() + "/" + schedulerRoutingKey;
     }
 
-    public record RoutingKey(
-            String scheduler
-    ) {
+    public record RoutingKey(String scheduler) {
     }
 
-    public record AadAuth(
-            String tenantId,
-            String clientId,
-            String clientSecret
-    ) {
+    public record AadAuth(String tenantId, String clientId, String clientSecret) {
         /**
          * Checks if AAD authentication is enabled by verifying all required fields are present.
          *
          * @return true if all AAD credentials are provided, false otherwise
          */
         public boolean isEnabled() {
-            return StringUtils.isNotBlank(tenantId)
-                    && StringUtils.isNotBlank(clientId)
+            return StringUtils.isNotBlank(tenantId) && StringUtils.isNotBlank(clientId)
                     && StringUtils.isNotBlank(clientSecret);
         }
     }
 
     /**
-     * Connection pool configuration for JmsPoolConnectionFactory.
-     * Used for both ServiceBus and RabbitMQ producer connection factories.
+     * Connection pool configuration for JmsPoolConnectionFactory. Used for both ServiceBus and RabbitMQ producer
+     * connection factories.
      */
-    public record Pool(
-            Integer maxConnections,
-            Integer connectionIdleTimeout,
-            Integer connectionCheckInterval,
-            Integer maxSessionsPerConnection,
-            Boolean useAnonymousProducers
-    ) {
+    public record Pool(Integer maxConnections, Integer connectionIdleTimeout, Integer connectionCheckInterval,
+            Integer maxSessionsPerConnection, Boolean useAnonymousProducers) {
         public Pool {
-            if (maxConnections == null || maxConnections <= 0) maxConnections = 1;
-            if (connectionIdleTimeout == null) connectionIdleTimeout = 30000;
-            if (connectionCheckInterval == null) connectionCheckInterval = 60000;
-            if (maxSessionsPerConnection == null || maxSessionsPerConnection <= 0) maxSessionsPerConnection = 500;
-            if (useAnonymousProducers == null) useAnonymousProducers = true;
+            if (maxConnections == null || maxConnections <= 0) {
+                maxConnections = 1;
+            }
+            if (connectionIdleTimeout == null) {
+                connectionIdleTimeout = 30000;
+            }
+            if (connectionCheckInterval == null) {
+                connectionCheckInterval = 60000;
+            }
+            if (maxSessionsPerConnection == null || maxSessionsPerConnection <= 0) {
+                maxSessionsPerConnection = 500;
+            }
+            if (useAnonymousProducers == null) {
+                useAnonymousProducers = true;
+            }
         }
     }
 
     public enum BrokerType {
-        RABBITMQ,
-        SERVICEBUS
+        RABBITMQ, SERVICEBUS
     }
 }

--- a/src/main/java/com/otilm/scheduler/service/impl/SchedulerServiceImpl.java
+++ b/src/main/java/com/otilm/scheduler/service/impl/SchedulerServiceImpl.java
@@ -10,16 +10,21 @@ import com.otilm.api.model.scheduler.SchedulerStatus;
 import com.otilm.scheduler.constants.JobConstants;
 import com.otilm.scheduler.service.SchedulerService;
 import com.otilm.scheduler.utils.SchedulerUtils;
-import org.quartz.*;
+import java.util.ArrayList;
+import java.util.List;
+import org.quartz.CronExpression;
+import org.quartz.CronTrigger;
+import org.quartz.JobDetail;
+import org.quartz.JobKey;
+import org.quartz.Scheduler;
+import org.quartz.Trigger;
+import org.quartz.TriggerKey;
 import org.quartz.impl.matchers.GroupMatcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Service
 @Transactional
@@ -38,17 +43,19 @@ public class SchedulerServiceImpl implements SchedulerService {
                 return;
             }
 
-            if(!CronExpression.isValidExpression(schedulerDetail.getCronExpression())) {
+            if (!CronExpression.isValidExpression(schedulerDetail.getCronExpression())) {
                 throw new ValidationException(ValidationError.create("Invalid format of CRON expression"));
             }
 
             logger.info("Scheduling new job withe name {}", schedulerDetail.getJobName());
-            final JobDetail jobDetail
-                    = SchedulerUtils.prepareJobDetail(schedulerDetail.getJobName(), schedulerDetail.getClassNameToBeExecuted());
-            final Trigger jobTrigger
-                    = SchedulerUtils.prepareTrigger(schedulerDetail.getJobName(), schedulerDetail.getCronExpression());
+            final JobDetail jobDetail = SchedulerUtils
+                    .prepareJobDetail(schedulerDetail.getJobName(), schedulerDetail.getClassNameToBeExecuted());
+            final Trigger jobTrigger = SchedulerUtils
+                    .prepareTrigger(schedulerDetail.getJobName(), schedulerDetail.getCronExpression());
             scheduler.scheduleJob(jobDetail, jobTrigger);
-            logger.info("Job {} scheduled with by {}", schedulerDetail.getJobName(), schedulerDetail.getCronExpression());
+            logger
+                    .info("Job {} scheduled with by {}", schedulerDetail.getJobName(),
+                            schedulerDetail.getCronExpression());
         } catch (org.quartz.SchedulerException e) {
             logger.error("Unable to schedule job {}", schedulerDetail.getJobName(), e.getMessage());
             throw new SchedulerException(e.getMessage());
@@ -71,7 +78,7 @@ public class SchedulerServiceImpl implements SchedulerService {
             scheduler.deleteJob(new JobKey(jobName, JobConstants.GROUP_NAME));
             logger.info("Job {} was unregistered.", jobName);
         } catch (org.quartz.SchedulerException e) {
-            logger.error("Unable to unregister job {}" , jobName);
+            logger.error("Unable to unregister job {}", jobName);
             throw new SchedulerException(e.getMessage());
         }
     }
@@ -83,9 +90,11 @@ public class SchedulerServiceImpl implements SchedulerService {
         try {
             for (final JobKey jobKey : scheduler.getJobKeys(GroupMatcher.jobGroupEquals(JobConstants.GROUP_NAME))) {
                 final JobDetail jobDetail = scheduler.getJobDetail(jobKey);
-                final CronTrigger trigger = (CronTrigger) scheduler.getTrigger(new TriggerKey(jobKey.getName() + JobConstants.JOB_TRIGGER_SUFFIX));
+                final CronTrigger trigger = (CronTrigger) scheduler
+                        .getTrigger(new TriggerKey(jobKey.getName() + JobConstants.JOB_TRIGGER_SUFFIX));
                 schedulerDetailList
-                        .add(new SchedulerJobDto(jobKey.getName(), trigger.getCronExpression(), jobDetail.getJobDataMap().getString(JobConstants.CLASS_TOBE_EXECUTED)));
+                        .add(new SchedulerJobDto(jobKey.getName(), trigger.getCronExpression(),
+                                jobDetail.getJobDataMap().getString(JobConstants.CLASS_TOBE_EXECUTED)));
             }
         } catch (org.quartz.SchedulerException e) {
             logger.error("Unable to retrieve list of registered jobs.", e.getMessage());
@@ -120,7 +129,6 @@ public class SchedulerServiceImpl implements SchedulerService {
             throw new SchedulerException(e.getMessage());
         }
     }
-
 
     // SETTERs
 

--- a/src/main/java/com/otilm/scheduler/utils/SchedulerUtils.java
+++ b/src/main/java/com/otilm/scheduler/utils/SchedulerUtils.java
@@ -2,23 +2,28 @@ package com.otilm.scheduler.utils;
 
 import com.otilm.scheduler.constants.JobConstants;
 import com.otilm.scheduler.jobs.SchedulerJob;
-import org.quartz.*;
+import org.quartz.CronScheduleBuilder;
+import org.quartz.JobBuilder;
+import org.quartz.JobDetail;
+import org.quartz.Trigger;
+import org.quartz.TriggerBuilder;
 
 public class SchedulerUtils {
 
     public static JobDetail prepareJobDetail(final String jobName, final String className) {
-        return JobBuilder.newJob(SchedulerJob.class)
+        return JobBuilder
+                .newJob(SchedulerJob.class)
                 .withIdentity(jobName, JobConstants.GROUP_NAME)
                 .usingJobData(JobConstants.CLASS_TOBE_EXECUTED, className)
                 .build();
     }
 
     public static Trigger prepareTrigger(final String jobName, final String cronExpression) {
-        return TriggerBuilder.newTrigger()
+        return TriggerBuilder
+                .newTrigger()
                 .withIdentity(jobName + JobConstants.JOB_TRIGGER_SUFFIX, JobConstants.GROUP_NAME)
                 .withSchedule(CronScheduleBuilder.cronSchedule(cronExpression))
                 .build();
     }
-
 
 }

--- a/src/main/java/db/migration/RebrandJobDataMigration.java
+++ b/src/main/java/db/migration/RebrandJobDataMigration.java
@@ -1,5 +1,9 @@
 package db.migration;
 
+import java.nio.charset.StandardCharsets;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.Arrays;
 import liquibase.change.custom.CustomTaskChange;
 import liquibase.database.Database;
 import liquibase.database.jvm.JdbcConnection;
@@ -7,11 +11,6 @@ import liquibase.exception.CustomChangeException;
 import liquibase.exception.SetupException;
 import liquibase.exception.ValidationErrors;
 import liquibase.resource.ResourceAccessor;
-
-import java.nio.charset.StandardCharsets;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.util.Arrays;
 
 public class RebrandJobDataMigration implements CustomTaskChange {
 
@@ -21,15 +20,17 @@ public class RebrandJobDataMigration implements CustomTaskChange {
             JdbcConnection conn = (JdbcConnection) database.getConnection();
 
             try (var stmt = conn.createStatement();
-                 ResultSet rs = stmt.executeQuery(
-                         "SELECT sched_name, job_name, job_group, job_data FROM qrtz_job_details WHERE job_data IS NOT NULL")) {
+                    ResultSet rs = stmt
+                            .executeQuery(
+                                    "SELECT sched_name, job_name, job_group, job_data FROM qrtz_job_details WHERE job_data IS NOT NULL")) {
 
                 while (rs.next()) {
                     byte[] jobData = rs.getBytes("job_data");
                     byte[] updated = replaceInSerializedBytes(jobData);
                     if (!Arrays.equals(updated, jobData)) {
-                        try (PreparedStatement ps = conn.prepareStatement(
-                                "UPDATE qrtz_job_details SET job_data = ? WHERE sched_name = ? AND job_name = ? AND job_group = ?")) {
+                        try (PreparedStatement ps = conn
+                                .prepareStatement(
+                                        "UPDATE qrtz_job_details SET job_data = ? WHERE sched_name = ? AND job_name = ? AND job_group = ?")) {
                             ps.setBytes(1, updated);
                             ps.setString(2, rs.getString("sched_name"));
                             ps.setString(3, rs.getString("job_name"));
@@ -63,8 +64,9 @@ public class RebrandJobDataMigration implements CustomTaskChange {
             result[lengthPos] = (byte) ((newLength >> 8) & 0xFF);
             result[lengthPos + 1] = (byte) (newLength & 0xFF);
             System.arraycopy(newBytes, 0, result, lengthPos + 2, newBytes.length);
-            System.arraycopy(data, pos + oldBytes.length, result, lengthPos + 2 + newBytes.length,
-                    data.length - pos - oldBytes.length);
+            System
+                    .arraycopy(data, pos + oldBytes.length, result, lengthPos + 2 + newBytes.length,
+                            data.length - pos - oldBytes.length);
             data = result;
         }
         return data;
@@ -72,14 +74,18 @@ public class RebrandJobDataMigration implements CustomTaskChange {
 
     private int indexOf(byte[] data, byte[] pattern) {
         for (int i = 0; i <= data.length - pattern.length; i++) {
-            if (matches(data, i, pattern)) return i;
+            if (matches(data, i, pattern)) {
+                return i;
+            }
         }
         return -1;
     }
 
     private boolean matches(byte[] data, int offset, byte[] pattern) {
         for (int j = 0; j < pattern.length; j++) {
-            if (data[offset + j] != pattern[j]) return false;
+            if (data[offset + j] != pattern[j]) {
+                return false;
+            }
         }
         return true;
     }

--- a/src/test/java/com/otilm/scheduler/messaging/JmsMessageProducerTest.java
+++ b/src/test/java/com/otilm/scheduler/messaging/JmsMessageProducerTest.java
@@ -11,39 +11,40 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.jms.core.JmsTemplate;
 import org.springframework.jms.core.MessagePostProcessor;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class JmsMessageProducerTest {
 
     @Mock
     private JmsTemplate jmsTemplate;
-    
+
     @Mock
     private MessagePostProcessor messagePostProcessor;
-    
+
     @Mock
     private MessagingProperties messagingProperties;
-    
+
     @Mock
     private SchedulerJobExecutionMessage schedulerJobExecutionMessage;
-    
+
     private JmsMessageProducer jmsMessageProducer;
-    
+
     @BeforeEach
     void setUp() {
         jmsMessageProducer = new JmsMessageProducer(jmsTemplate, messagePostProcessor, messagingProperties);
     }
-    
+
     @Test
     void testSendMessage_shouldCallJmsTemplateWithCorrectParameters() {
         // Given
         String exchangeName = "test.exchange";
         when(messagingProperties.producerDestination()).thenReturn(exchangeName);
-        
+
         // When
         jmsMessageProducer.sendMessage(schedulerJobExecutionMessage);
-        
+
         // Then
         verify(jmsTemplate).convertAndSend(exchangeName, schedulerJobExecutionMessage, messagePostProcessor);
     }

--- a/src/test/java/com/otilm/scheduler/messaging/RoutingKeyMessagePostProcessorTest.java
+++ b/src/test/java/com/otilm/scheduler/messaging/RoutingKeyMessagePostProcessorTest.java
@@ -9,7 +9,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class RoutingKeyMessagePostProcessorTest {
@@ -19,14 +21,9 @@ class RoutingKeyMessagePostProcessorTest {
 
     @Test
     void postProcessMessage_validRoutingKey_setsJmsType() throws JMSException {
-        MessagingProperties props = new MessagingProperties(
-                MessagingProperties.BrokerType.RABBITMQ,
-                "amqp://localhost:5672", null, null,
-                "user", "pass", null,
-                "exchange",
-                new MessagingProperties.RoutingKey("my.routing.key"),
-                null, null
-        );
+        MessagingProperties props = new MessagingProperties(MessagingProperties.BrokerType.RABBITMQ,
+                "amqp://localhost:5672", null, null, "user", "pass", null, "exchange",
+                new MessagingProperties.RoutingKey("my.routing.key"), null, null);
         RoutingKeyMessagePostProcessor processor = new RoutingKeyMessagePostProcessor(props);
 
         Message result = processor.postProcessMessage(message);
@@ -37,12 +34,8 @@ class RoutingKeyMessagePostProcessorTest {
 
     @Test
     void postProcessMessage_nullRoutingKey_doesNotSetJmsType() throws JMSException {
-        MessagingProperties props = new MessagingProperties(
-                MessagingProperties.BrokerType.RABBITMQ,
-                "amqp://localhost:5672", null, null,
-                "user", "pass", null,
-                "exchange", null, null, null
-        );
+        MessagingProperties props = new MessagingProperties(MessagingProperties.BrokerType.RABBITMQ,
+                "amqp://localhost:5672", null, null, "user", "pass", null, "exchange", null, null, null);
         RoutingKeyMessagePostProcessor processor = new RoutingKeyMessagePostProcessor(props);
 
         Message result = processor.postProcessMessage(message);
@@ -53,14 +46,9 @@ class RoutingKeyMessagePostProcessorTest {
 
     @Test
     void postProcessMessage_blankRoutingKey_doesNotSetJmsType() throws JMSException {
-        MessagingProperties props = new MessagingProperties(
-                MessagingProperties.BrokerType.RABBITMQ,
-                "amqp://localhost:5672", null, null,
-                "user", "pass", null,
-                "exchange",
-                new MessagingProperties.RoutingKey("   "),
-                null, null
-        );
+        MessagingProperties props = new MessagingProperties(MessagingProperties.BrokerType.RABBITMQ,
+                "amqp://localhost:5672", null, null, "user", "pass", null, "exchange",
+                new MessagingProperties.RoutingKey("   "), null, null);
         RoutingKeyMessagePostProcessor processor = new RoutingKeyMessagePostProcessor(props);
 
         Message result = processor.postProcessMessage(message);
@@ -71,14 +59,9 @@ class RoutingKeyMessagePostProcessorTest {
 
     @Test
     void postProcessMessage_nullSchedulerKey_doesNotSetJmsType() throws JMSException {
-        MessagingProperties props = new MessagingProperties(
-                MessagingProperties.BrokerType.RABBITMQ,
-                "amqp://localhost:5672", null, null,
-                "user", "pass", null,
-                "exchange",
-                new MessagingProperties.RoutingKey(null),
-                null, null
-        );
+        MessagingProperties props = new MessagingProperties(MessagingProperties.BrokerType.RABBITMQ,
+                "amqp://localhost:5672", null, null, "user", "pass", null, "exchange",
+                new MessagingProperties.RoutingKey(null), null, null);
         RoutingKeyMessagePostProcessor processor = new RoutingKeyMessagePostProcessor(props);
 
         Message result = processor.postProcessMessage(message);

--- a/src/test/java/com/otilm/scheduler/messaging/configuration/AadTokenProviderTest.java
+++ b/src/test/java/com/otilm/scheduler/messaging/configuration/AadTokenProviderTest.java
@@ -3,6 +3,7 @@ package com.otilm.scheduler.messaging.configuration;
 import com.azure.core.credential.AccessToken;
 import com.azure.core.credential.TokenCredential;
 import com.azure.core.credential.TokenRequestContext;
+import java.time.OffsetDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -10,11 +11,12 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Mono;
 
-import java.time.OffsetDateTime;
-
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class AadTokenProviderTest {

--- a/src/test/java/com/otilm/scheduler/messaging/configuration/JmsConfigurationTest.java
+++ b/src/test/java/com/otilm/scheduler/messaging/configuration/JmsConfigurationTest.java
@@ -14,7 +14,10 @@ import org.springframework.jms.support.converter.MessageConverter;
 import org.springframework.jms.support.converter.MessageType;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(MockitoExtension.class)
 class JmsConfigurationTest {
@@ -30,12 +33,8 @@ class JmsConfigurationTest {
 
     @Test
     void connectionFactory_rabbitMq_setsUsernameAndPassword() {
-        MessagingProperties props = new MessagingProperties(
-                MessagingProperties.BrokerType.RABBITMQ,
-                "amqp://localhost:5672", null, null,
-                "myUser", "myPass", null,
-                "exchange", null, null, null
-        );
+        MessagingProperties props = new MessagingProperties(MessagingProperties.BrokerType.RABBITMQ,
+                "amqp://localhost:5672", null, null, "myUser", "myPass", null, "exchange", null, null, null);
 
         ConnectionFactory factory = jmsConfiguration.connectionFactory(props);
 
@@ -47,12 +46,8 @@ class JmsConfigurationTest {
 
     @Test
     void connectionFactory_rabbitMqWithVhost_addsVhostQueryParam() {
-        MessagingProperties props = new MessagingProperties(
-                MessagingProperties.BrokerType.RABBITMQ,
-                "amqp://localhost:5672", null, null,
-                "user", "pass", "myVhost",
-                "exchange", null, null, null
-        );
+        MessagingProperties props = new MessagingProperties(MessagingProperties.BrokerType.RABBITMQ,
+                "amqp://localhost:5672", null, null, "user", "pass", "myVhost", "exchange", null, null, null);
 
         ConnectionFactory factory = jmsConfiguration.connectionFactory(props);
 
@@ -63,12 +58,8 @@ class JmsConfigurationTest {
 
     @Test
     void connectionFactory_rabbitMqWithoutVhost_noQueryParam() {
-        MessagingProperties props = new MessagingProperties(
-                MessagingProperties.BrokerType.RABBITMQ,
-                "amqp://localhost:5672", null, null,
-                "user", "pass", null,
-                "exchange", null, null, null
-        );
+        MessagingProperties props = new MessagingProperties(MessagingProperties.BrokerType.RABBITMQ,
+                "amqp://localhost:5672", null, null, "user", "pass", null, "exchange", null, null, null);
 
         ConnectionFactory factory = jmsConfiguration.connectionFactory(props);
 
@@ -80,12 +71,9 @@ class JmsConfigurationTest {
 
     @Test
     void connectionFactory_serviceBusWithSas_setsUsernameAndPassword() {
-        MessagingProperties props = new MessagingProperties(
-                MessagingProperties.BrokerType.SERVICEBUS,
-                "amqps://sb.servicebus.windows.net", null, null,
-                "sasKeyName", "sasKey", null,
-                "exchange", null, null, null
-        );
+        MessagingProperties props = new MessagingProperties(MessagingProperties.BrokerType.SERVICEBUS,
+                "amqps://sb.servicebus.windows.net", null, null, "sasKeyName", "sasKey", null, "exchange", null, null,
+                null);
 
         ConnectionFactory factory = jmsConfiguration.connectionFactory(props);
 
@@ -96,14 +84,9 @@ class JmsConfigurationTest {
 
     @Test
     void connectionFactory_serviceBusWithAad_setsJwtUsername() {
-        MessagingProperties props = new MessagingProperties(
-                MessagingProperties.BrokerType.SERVICEBUS,
-                "amqps://sb.servicebus.windows.net", null, null,
-                null, null, null,
-                "exchange", null,
-                new MessagingProperties.AadAuth("tenant", "client", "secret"),
-                null
-        );
+        MessagingProperties props = new MessagingProperties(MessagingProperties.BrokerType.SERVICEBUS,
+                "amqps://sb.servicebus.windows.net", null, null, null, null, null, "exchange", null,
+                new MessagingProperties.AadAuth("tenant", "client", "secret"), null);
 
         ConnectionFactory factory = jmsConfiguration.connectionFactory(props);
 
@@ -115,13 +98,9 @@ class JmsConfigurationTest {
 
     @Test
     void producerConnectionFactory_appliesPoolConfig() {
-        MessagingProperties props = new MessagingProperties(
-                MessagingProperties.BrokerType.RABBITMQ,
-                "amqp://localhost:5672", null, null,
-                "user", "pass", null,
-                "exchange", null, null,
-                new MessagingProperties.Pool(3, 15000, 30000, 200, false)
-        );
+        MessagingProperties props = new MessagingProperties(MessagingProperties.BrokerType.RABBITMQ,
+                "amqp://localhost:5672", null, null, "user", "pass", null, "exchange", null, null,
+                new MessagingProperties.Pool(3, 15000, 30000, 200, false));
         ConnectionFactory innerFactory = jmsConfiguration.connectionFactory(props);
 
         JmsPoolConnectionFactory pool = jmsConfiguration.producerConnectionFactory(innerFactory, props);
@@ -139,12 +118,8 @@ class JmsConfigurationTest {
 
     @Test
     void producerConnectionFactory_nullPoolConfig_usesDefaults() {
-        MessagingProperties props = new MessagingProperties(
-                MessagingProperties.BrokerType.RABBITMQ,
-                "amqp://localhost:5672", null, null,
-                "user", "pass", null,
-                "exchange", null, null, null
-        );
+        MessagingProperties props = new MessagingProperties(MessagingProperties.BrokerType.RABBITMQ,
+                "amqp://localhost:5672", null, null, "user", "pass", null, "exchange", null, null, null);
         ConnectionFactory innerFactory = jmsConfiguration.connectionFactory(props);
 
         JmsPoolConnectionFactory pool = jmsConfiguration.producerConnectionFactory(innerFactory, props);
@@ -166,8 +141,8 @@ class JmsConfigurationTest {
     void messageConverter_targetTypeIsText() {
         MessageConverter converter = jmsConfiguration.messageConverter(new ObjectMapper());
 
-        MappingJackson2MessageConverter jacksonConverter =
-                assertInstanceOf(MappingJackson2MessageConverter.class, converter);
+        MappingJackson2MessageConverter jacksonConverter = assertInstanceOf(MappingJackson2MessageConverter.class,
+                converter);
         assertEquals(MessageType.TEXT, ReflectionTestUtils.getField(jacksonConverter, "targetType"));
     }
 
@@ -175,12 +150,8 @@ class JmsConfigurationTest {
 
     @Test
     void jmsTemplate_serviceBus_pubSubDomainTrue() {
-        MessagingProperties props = new MessagingProperties(
-                MessagingProperties.BrokerType.SERVICEBUS,
-                "amqps://sb.servicebus.windows.net", null, null,
-                "user", "pass", null,
-                "exchange", null, null, null
-        );
+        MessagingProperties props = new MessagingProperties(MessagingProperties.BrokerType.SERVICEBUS,
+                "amqps://sb.servicebus.windows.net", null, null, "user", "pass", null, "exchange", null, null, null);
         ConnectionFactory innerFactory = jmsConfiguration.connectionFactory(props);
         JmsPoolConnectionFactory pool = jmsConfiguration.producerConnectionFactory(innerFactory, props);
         MessageConverter converter = jmsConfiguration.messageConverter(new ObjectMapper());
@@ -195,12 +166,8 @@ class JmsConfigurationTest {
 
     @Test
     void jmsTemplate_rabbitMq_pubSubDomainFalse() {
-        MessagingProperties props = new MessagingProperties(
-                MessagingProperties.BrokerType.RABBITMQ,
-                "amqp://localhost:5672", null, null,
-                "user", "pass", null,
-                "exchange", null, null, null
-        );
+        MessagingProperties props = new MessagingProperties(MessagingProperties.BrokerType.RABBITMQ,
+                "amqp://localhost:5672", null, null, "user", "pass", null, "exchange", null, null, null);
         ConnectionFactory innerFactory = jmsConfiguration.connectionFactory(props);
         JmsPoolConnectionFactory pool = jmsConfiguration.producerConnectionFactory(innerFactory, props);
         MessageConverter converter = jmsConfiguration.messageConverter(new ObjectMapper());

--- a/src/test/java/com/otilm/scheduler/messaging/configuration/MessagingPropertiesTest.java
+++ b/src/test/java/com/otilm/scheduler/messaging/configuration/MessagingPropertiesTest.java
@@ -2,7 +2,11 @@ package com.otilm.scheduler.messaging.configuration;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class MessagingPropertiesTest {
 
@@ -10,113 +14,78 @@ class MessagingPropertiesTest {
 
     @Test
     void rabbitMq_validWithBrokerUrl() {
-        MessagingProperties props = new MessagingProperties(
-                MessagingProperties.BrokerType.RABBITMQ,
-                "amqp://localhost:5672", null, null,
-                "user", "pass", null,
-                "exchange", null, null, null
-        );
+        MessagingProperties props = new MessagingProperties(MessagingProperties.BrokerType.RABBITMQ,
+                "amqp://localhost:5672", null, null, "user", "pass", null, "exchange", null, null, null);
         assertNotNull(props);
     }
 
     @Test
     void rabbitMq_validWithHostAndPort() {
-        MessagingProperties props = new MessagingProperties(
-                MessagingProperties.BrokerType.RABBITMQ,
-                null, "localhost", 5672,
-                "user", "pass", null,
-                "exchange", null, null, null
-        );
+        MessagingProperties props = new MessagingProperties(MessagingProperties.BrokerType.RABBITMQ, null, "localhost",
+                5672, "user", "pass", null, "exchange", null, null, null);
         assertNotNull(props);
     }
 
     @Test
     void rabbitMq_invalidWithoutBrokerUrlOrHostPort() {
-        assertThrows(IllegalArgumentException.class, () -> new MessagingProperties(
-                MessagingProperties.BrokerType.RABBITMQ,
-                null, null, null,
-                "user", "pass", null,
-                "exchange", null, null, null
-        ));
+        assertThrows(IllegalArgumentException.class,
+                () -> new MessagingProperties(MessagingProperties.BrokerType.RABBITMQ, null, null, null, "user", "pass",
+                        null, "exchange", null, null, null));
     }
 
     @Test
     void rabbitMq_invalidWithoutUsernamePassword() {
-        assertThrows(IllegalArgumentException.class, () -> new MessagingProperties(
-                MessagingProperties.BrokerType.RABBITMQ,
-                "amqp://localhost:5672", null, null,
-                null, null, null,
-                "exchange", null, null, null
-        ));
+        assertThrows(IllegalArgumentException.class,
+                () -> new MessagingProperties(MessagingProperties.BrokerType.RABBITMQ, "amqp://localhost:5672", null,
+                        null, null, null, null, "exchange", null, null, null));
     }
 
     // --- ServiceBus validation ---
 
     @Test
     void serviceBus_validWithSasAuth() {
-        MessagingProperties props = new MessagingProperties(
-                MessagingProperties.BrokerType.SERVICEBUS,
-                "amqps://sb.servicebus.windows.net", null, null,
-                "sasKeyName", "sasKey", null,
-                "exchange", null, null, null
-        );
+        MessagingProperties props = new MessagingProperties(MessagingProperties.BrokerType.SERVICEBUS,
+                "amqps://sb.servicebus.windows.net", null, null, "sasKeyName", "sasKey", null, "exchange", null, null,
+                null);
         assertNotNull(props);
     }
 
     @Test
     void serviceBus_validWithAadAuth() {
-        MessagingProperties props = new MessagingProperties(
-                MessagingProperties.BrokerType.SERVICEBUS,
-                "amqps://sb.servicebus.windows.net", null, null,
-                null, null, null,
-                "exchange", null,
-                new MessagingProperties.AadAuth("tenant", "client", "secret"),
-                null
-        );
+        MessagingProperties props = new MessagingProperties(MessagingProperties.BrokerType.SERVICEBUS,
+                "amqps://sb.servicebus.windows.net", null, null, null, null, null, "exchange", null,
+                new MessagingProperties.AadAuth("tenant", "client", "secret"), null);
         assertNotNull(props);
     }
 
     @Test
     void serviceBus_invalidWithoutBrokerUrl() {
-        assertThrows(IllegalArgumentException.class, () -> new MessagingProperties(
-                MessagingProperties.BrokerType.SERVICEBUS,
-                null, null, null,
-                "user", "pass", null,
-                "exchange", null, null, null
-        ));
+        assertThrows(IllegalArgumentException.class,
+                () -> new MessagingProperties(MessagingProperties.BrokerType.SERVICEBUS, null, null, null, "user",
+                        "pass", null, "exchange", null, null, null));
     }
 
     @Test
     void serviceBus_invalidWithoutAnyAuth() {
-        assertThrows(IllegalArgumentException.class, () -> new MessagingProperties(
-                MessagingProperties.BrokerType.SERVICEBUS,
-                "amqps://sb.servicebus.windows.net", null, null,
-                null, null, null,
-                "exchange", null, null, null
-        ));
+        assertThrows(IllegalArgumentException.class,
+                () -> new MessagingProperties(MessagingProperties.BrokerType.SERVICEBUS,
+                        "amqps://sb.servicebus.windows.net", null, null, null, null, null, "exchange", null, null,
+                        null));
     }
 
     // --- getEffectiveBrokerUrl ---
 
     @Test
     void getEffectiveBrokerUrl_returnsBrokerUrlWhenSet() {
-        MessagingProperties props = new MessagingProperties(
-                MessagingProperties.BrokerType.RABBITMQ,
-                "amqp://myhost:9999", null, null,
-                "user", "pass", null,
-                "exchange", null, null, null
-        );
+        MessagingProperties props = new MessagingProperties(MessagingProperties.BrokerType.RABBITMQ,
+                "amqp://myhost:9999", null, null, "user", "pass", null, "exchange", null, null, null);
         assertEquals("amqp://myhost:9999", props.getEffectiveBrokerUrl());
     }
 
     @Test
     void getEffectiveBrokerUrl_constructsFromHostAndPort() {
-        MessagingProperties props = new MessagingProperties(
-                MessagingProperties.BrokerType.RABBITMQ,
-                null, "myhost", 5672,
-                "user", "pass", null,
-                "exchange", null, null, null
-        );
+        MessagingProperties props = new MessagingProperties(MessagingProperties.BrokerType.RABBITMQ, null, "myhost",
+                5672, "user", "pass", null, "exchange", null, null, null);
         assertEquals("amqp://myhost:5672", props.getEffectiveBrokerUrl());
     }
 
@@ -124,49 +93,31 @@ class MessagingPropertiesTest {
 
     @Test
     void producerDestination_serviceBus_returnsExchange() {
-        MessagingProperties props = new MessagingProperties(
-                MessagingProperties.BrokerType.SERVICEBUS,
-                "amqps://sb.servicebus.windows.net", null, null,
-                "user", "pass", null,
-                "myExchange", null, null, null
-        );
+        MessagingProperties props = new MessagingProperties(MessagingProperties.BrokerType.SERVICEBUS,
+                "amqps://sb.servicebus.windows.net", null, null, "user", "pass", null, "myExchange", null, null, null);
         assertEquals("myExchange", props.producerDestination());
     }
 
     @Test
     void producerDestination_rabbitMq_returnsExchangePath() {
-        MessagingProperties props = new MessagingProperties(
-                MessagingProperties.BrokerType.RABBITMQ,
-                "amqp://localhost:5672", null, null,
-                "user", "pass", null,
-                "myExchange",
-                new MessagingProperties.RoutingKey("myKey"),
-                null, null
-        );
+        MessagingProperties props = new MessagingProperties(MessagingProperties.BrokerType.RABBITMQ,
+                "amqp://localhost:5672", null, null, "user", "pass", null, "myExchange",
+                new MessagingProperties.RoutingKey("myKey"), null, null);
         assertEquals("/exchanges/myExchange/myKey", props.producerDestination());
     }
 
     @Test
     void producerDestination_rabbitMq_nullRoutingKey_returnsExchangePathWithEmptyKey() {
-        MessagingProperties props = new MessagingProperties(
-                MessagingProperties.BrokerType.RABBITMQ,
-                "amqp://localhost:5672", null, null,
-                "user", "pass", null,
-                "myExchange", null, null, null
-        );
+        MessagingProperties props = new MessagingProperties(MessagingProperties.BrokerType.RABBITMQ,
+                "amqp://localhost:5672", null, null, "user", "pass", null, "myExchange", null, null, null);
         assertEquals("/exchanges/myExchange/", props.producerDestination());
     }
 
     @Test
     void producerDestination_rabbitMq_nullSchedulerKey_returnsExchangePathWithEmptyKey() {
-        MessagingProperties props = new MessagingProperties(
-                MessagingProperties.BrokerType.RABBITMQ,
-                "amqp://localhost:5672", null, null,
-                "user", "pass", null,
-                "myExchange",
-                new MessagingProperties.RoutingKey(null),
-                null, null
-        );
+        MessagingProperties props = new MessagingProperties(MessagingProperties.BrokerType.RABBITMQ,
+                "amqp://localhost:5672", null, null, "user", "pass", null, "myExchange",
+                new MessagingProperties.RoutingKey(null), null, null);
         assertEquals("/exchanges/myExchange/", props.producerDestination());
     }
 

--- a/src/test/java/com/otilm/scheduler/service/impl/SchedulerServiceImplTest.java
+++ b/src/test/java/com/otilm/scheduler/service/impl/SchedulerServiceImplTest.java
@@ -7,23 +7,33 @@ import com.otilm.api.model.scheduler.SchedulerRequestDto;
 import com.otilm.api.model.scheduler.SchedulerResponseDto;
 import com.otilm.api.model.scheduler.SchedulerStatus;
 import com.otilm.scheduler.constants.JobConstants;
+import java.util.HashSet;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.quartz.*;
+import org.quartz.JobDetail;
+import org.quartz.JobKey;
+import org.quartz.Scheduler;
+import org.quartz.Trigger;
+import org.quartz.TriggerKey;
 import org.quartz.impl.JobDetailImpl;
 import org.quartz.impl.matchers.GroupMatcher;
 import org.quartz.impl.triggers.CronTriggerImpl;
 
-import java.util.HashSet;
-import java.util.Set;
-
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class SchedulerServiceImplTest {
@@ -80,7 +90,8 @@ class SchedulerServiceImplTest {
     void createNewJobThrowsSchedulerException() throws Exception {
         when(scheduler.checkExists(any(JobKey.class))).thenReturn(false);
         doThrow(new org.quartz.SchedulerException("Scheduler error"))
-                .when(scheduler).scheduleJob(any(JobDetail.class), any(Trigger.class));
+                .when(scheduler)
+                .scheduleJob(any(JobDetail.class), any(Trigger.class));
 
         assertThrows(SchedulerException.class, () -> schedulerService.createNewJob(schedulerRequestDto));
     }
@@ -115,8 +126,7 @@ class SchedulerServiceImplTest {
 
     @Test
     void updateJobThrowsSchedulerExceptionOnDelete() throws Exception {
-        doThrow(new org.quartz.SchedulerException("Delete error"))
-                .when(scheduler).deleteJob(any(JobKey.class));
+        doThrow(new org.quartz.SchedulerException("Delete error")).when(scheduler).deleteJob(any(JobKey.class));
 
         assertThrows(SchedulerException.class, () -> schedulerService.updateJob(schedulerRequestDto));
     }
@@ -140,8 +150,7 @@ class SchedulerServiceImplTest {
 
     @Test
     void deleteJobThrowsSchedulerException() throws Exception {
-        doThrow(new org.quartz.SchedulerException("Delete error"))
-                .when(scheduler).deleteJob(any(JobKey.class));
+        doThrow(new org.quartz.SchedulerException("Delete error")).when(scheduler).deleteJob(any(JobKey.class));
 
         assertThrows(SchedulerException.class, () -> schedulerService.deleteJob("testJob"));
     }
@@ -196,8 +205,7 @@ class SchedulerServiceImplTest {
 
     @Test
     void listJobsThrowsSchedulerException() throws Exception {
-        when(scheduler.getJobKeys(any(GroupMatcher.class)))
-                .thenThrow(new org.quartz.SchedulerException("List error"));
+        when(scheduler.getJobKeys(any(GroupMatcher.class))).thenThrow(new org.quartz.SchedulerException("List error"));
 
         assertThrows(SchedulerException.class, () -> schedulerService.listJobs());
     }
@@ -227,8 +235,7 @@ class SchedulerServiceImplTest {
 
     @Test
     void enableJobThrowsSchedulerException() throws Exception {
-        doThrow(new org.quartz.SchedulerException("Resume error"))
-                .when(scheduler).resumeJob(any(JobKey.class));
+        doThrow(new org.quartz.SchedulerException("Resume error")).when(scheduler).resumeJob(any(JobKey.class));
 
         assertThrows(SchedulerException.class, () -> schedulerService.enableJob("testJob"));
     }
@@ -242,8 +249,7 @@ class SchedulerServiceImplTest {
 
     @Test
     void disableJobThrowsSchedulerException() throws Exception {
-        doThrow(new org.quartz.SchedulerException("Pause error"))
-                .when(scheduler).pauseJob(any(JobKey.class));
+        doThrow(new org.quartz.SchedulerException("Pause error")).when(scheduler).pauseJob(any(JobKey.class));
 
         assertThrows(SchedulerException.class, () -> schedulerService.disableJob("testJob"));
     }
@@ -274,12 +280,11 @@ class SchedulerServiceImplTest {
     void createNewJobWithDifferentCronExpressions() throws Exception {
         when(scheduler.checkExists(any(JobKey.class))).thenReturn(false);
 
-        String[] validCronExpressions = {
-                "0 0 12 * * ?",           // Every day at noon
-                "0 15 10 * * ?",          // 10:15 AM every day
-                "0 0/5 * * * ?",          // Every 5 minutes
-                "0 0 0 1 1 ?",            // Midnight on January 1st
-                "0 0 22 ? * MON-FRI"      // 10 PM Monday through Friday
+        String[] validCronExpressions = {"0 0 12 * * ?", // Every day at noon
+                "0 15 10 * * ?", // 10:15 AM every day
+                "0 0/5 * * * ?", // Every 5 minutes
+                "0 0 0 1 1 ?", // Midnight on January 1st
+                "0 0 22 ? * MON-FRI" // 10 PM Monday through Friday
         };
 
         for (String cronExpression : validCronExpressions) {
@@ -288,14 +293,12 @@ class SchedulerServiceImplTest {
             schedulerService.createNewJob(schedulerRequestDto);
         }
 
-        verify(scheduler, times(validCronExpressions.length))
-                .scheduleJob(any(JobDetail.class), any(Trigger.class));
+        verify(scheduler, times(validCronExpressions.length)).scheduleJob(any(JobDetail.class), any(Trigger.class));
     }
 
     @Test
     void deleteNonExistentJob() throws Exception {
-        doThrow(new org.quartz.SchedulerException("Job not found"))
-                .when(scheduler).deleteJob(any(JobKey.class));
+        doThrow(new org.quartz.SchedulerException("Job not found")).when(scheduler).deleteJob(any(JobKey.class));
 
         assertThrows(SchedulerException.class, () -> schedulerService.deleteJob("nonExistentJob"));
     }
@@ -314,4 +317,3 @@ class SchedulerServiceImplTest {
         verify(scheduler).pauseJob(new JobKey("testJob", JobConstants.GROUP_NAME));
     }
 }
-

--- a/src/test/java/db/migration/RebrandJobDataMigrationTest.java
+++ b/src/test/java/db/migration/RebrandJobDataMigrationTest.java
@@ -1,13 +1,12 @@
 package db.migration;
 
-import org.junit.jupiter.api.Test;
-
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.HashMap;
 import java.util.Map;
+import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;


### PR DESCRIPTION
**This turns on the platform-wide Spotless and Checkstyle gates for `scheduler`, and reformats the tree to match them in one mechanical commit.**

The rules are not copied into this repository. They live in `com.otilm:build-tools` and arrive by inheriting the `com.otilm:dependencies` parent, added in [dependencies#140](https://github.com/OmniTrustILM/dependencies/pull/140).

## What each commit does

| Commit | Content |
|---|---|
| `f4d75a9` | One-shot `mvn spotless:apply`, plus the two Checkstyle rules Spotless cannot fix: 7 `NeedBraces` sites and 13 wildcard imports across 10 files |
| `c833736` | Records `f4d75a9` in `.git-blame-ignore-revs` |
| `8342a74` | Adds `.editorconfig` and `.gitattributes` |
| `76e918b` | Points the parent at `dependencies 1.4.3-SNAPSHOT` |

**The order is deliberate.** The parent bump is what activates the gates, so it lands last, after the tree is already clean. `mvn verify` was run at each of the four commits in a scratch worktree and passes at all of them — 70 tests, both gates clean. Nothing here is bisect-hostile.

**There are no behaviour changes.** Every line is formatting, braces around single-statement `if`s, or an expanded import.

## What changes for you day to day

`mvn verify` now runs two extra gates.

- **Spotless failures are mechanical.** Run `mvn spotless:apply` and they are gone.
- **Checkstyle failures are not.** Four rules only: `AvoidStarImport`, `NeedBraces`, `UnusedImports`, `RedundantImport`. Fix those by hand.

Your first Maven build after merging installs a `pre-commit` hook that formats staged Java files for you, so most violations never reach CI. **It replaces any existing `.git/hooks/pre-commit`, on every build.** Use `-Dgitbuildhook.install.skip=true` if you keep one of your own.

## Reviewing this

`f4d75a9` touches nearly every file, so read it with whitespace hidden — append `?w=1` to the Files-changed URL. The other three commits are small and worth reading normally.

`git blame` already skips the reformat: GitHub's blame view honours `.git-blame-ignore-revs` on its own, and the parent POM wires your local `git blame` to it on the next build.

## One thing to know about the parent version

`1.4.3-SNAPSHOT` is a snapshot, by team practice — `dependencies` is released only when ILM is. It resolves anonymously from Central Snapshots, which I verified on a clean local repository with no credentials. **Do not tag a `scheduler` release while the parent is a snapshot**; Central rejects a POM with a snapshot parent, and old snapshots are eventually pruned. At the next ILM release, `dependencies` gets released first and this bump becomes `1.4.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
