### PR TITLE
Fix logging defects and two SonarQube findings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <artifactId>scheduler</artifactId>
-    <version>1.1.1</version>
+    <version>1.1.2-SNAPSHOT</version>
     <name>scheduler</name>
 
     <description>scheduler</description>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.otilm</groupId>
             <artifactId>interfaces</artifactId>
-            <version>2.19.0</version>
+            <version>2.20.0-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.springdoc</groupId>

--- a/src/main/java/com/otilm/scheduler/ExceptionHandlingAdvice.java
+++ b/src/main/java/com/otilm/scheduler/ExceptionHandlingAdvice.java
@@ -8,7 +8,6 @@ import com.otilm.api.exception.ValidationError;
 import com.otilm.api.exception.ValidationException;
 import com.otilm.api.model.common.ErrorMessageDto;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -69,7 +68,7 @@ public class ExceptionHandlingAdvice {
     public List<String> handleValidationException(ValidationException ex) {
         LOG.info("HTTP 422: {}", ex.getMessage());
 
-        return ex.getErrors().stream().map(ValidationError::getErrorDescription).collect(Collectors.toList());
+        return ex.getErrors().stream().map(ValidationError::getErrorDescription).toList();
     }
 
     /**

--- a/src/main/java/com/otilm/scheduler/controllers/SchedulerController.java
+++ b/src/main/java/com/otilm/scheduler/controllers/SchedulerController.java
@@ -8,17 +8,16 @@ import io.swagger.v3.oas.annotations.Parameter;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/v1/scheduler")
 public interface SchedulerController {
 
-    @RequestMapping(path = "/create", method = RequestMethod.POST, consumes = {"application/json"}, produces = {
-            "application/json"})
+    @PostMapping(path = "/create", consumes = {"application/json"}, produces = {"application/json"})
     void createNewJob(@RequestBody SchedulerRequestDto schedulerDto) throws SchedulerException;
 
     @GetMapping(path = "/update")

--- a/src/main/java/com/otilm/scheduler/service/impl/SchedulerServiceImpl.java
+++ b/src/main/java/com/otilm/scheduler/service/impl/SchedulerServiceImpl.java
@@ -47,17 +47,17 @@ public class SchedulerServiceImpl implements SchedulerService {
                 throw new ValidationException(ValidationError.create("Invalid format of CRON expression"));
             }
 
-            logger.info("Scheduling new job withe name {}", schedulerDetail.getJobName());
+            logger.info("Scheduling new job with name {}", schedulerDetail.getJobName());
             final JobDetail jobDetail = SchedulerUtils
                     .prepareJobDetail(schedulerDetail.getJobName(), schedulerDetail.getClassNameToBeExecuted());
             final Trigger jobTrigger = SchedulerUtils
                     .prepareTrigger(schedulerDetail.getJobName(), schedulerDetail.getCronExpression());
             scheduler.scheduleJob(jobDetail, jobTrigger);
             logger
-                    .info("Job {} scheduled with by {}", schedulerDetail.getJobName(),
+                    .info("Job {} scheduled with CRON expression {}", schedulerDetail.getJobName(),
                             schedulerDetail.getCronExpression());
         } catch (org.quartz.SchedulerException e) {
-            logger.error("Unable to schedule job {}", schedulerDetail.getJobName(), e.getMessage());
+            logger.error("Unable to schedule job {}", schedulerDetail.getJobName(), e);
             throw new SchedulerException(e.getMessage());
         }
     }
@@ -78,7 +78,7 @@ public class SchedulerServiceImpl implements SchedulerService {
             scheduler.deleteJob(new JobKey(jobName, JobConstants.GROUP_NAME));
             logger.info("Job {} was unregistered.", jobName);
         } catch (org.quartz.SchedulerException e) {
-            logger.error("Unable to unregister job {}", jobName);
+            logger.error("Unable to unregister job {}", jobName, e);
             throw new SchedulerException(e.getMessage());
         }
     }
@@ -97,7 +97,7 @@ public class SchedulerServiceImpl implements SchedulerService {
                                 jobDetail.getJobDataMap().getString(JobConstants.CLASS_TOBE_EXECUTED)));
             }
         } catch (org.quartz.SchedulerException e) {
-            logger.error("Unable to retrieve list of registered jobs.", e.getMessage());
+            logger.error("Unable to retrieve list of registered jobs.", e);
             throw new SchedulerException(e.getMessage());
         }
 
@@ -113,7 +113,7 @@ public class SchedulerServiceImpl implements SchedulerService {
             scheduler.resumeJob(new JobKey(jobName, JobConstants.GROUP_NAME));
             logger.info("Job {} was resumed.", jobName);
         } catch (org.quartz.SchedulerException e) {
-            logger.error("Unable to resume job {}", jobName, e.getMessage());
+            logger.error("Unable to resume job {}", jobName, e);
             throw new SchedulerException(e.getMessage());
         }
     }
@@ -125,7 +125,7 @@ public class SchedulerServiceImpl implements SchedulerService {
             scheduler.pauseJob(new JobKey(jobName, JobConstants.GROUP_NAME));
             logger.info("Job {} was paused.", jobName);
         } catch (org.quartz.SchedulerException e) {
-            logger.error("Unable to pause job {}", jobName, e.getMessage());
+            logger.error("Unable to pause job {}", jobName, e);
             throw new SchedulerException(e.getMessage());
         }
     }

--- a/src/main/java/com/otilm/scheduler/service/impl/SchedulerServiceImpl.java
+++ b/src/main/java/com/otilm/scheduler/service/impl/SchedulerServiceImpl.java
@@ -58,7 +58,7 @@ public class SchedulerServiceImpl implements SchedulerService {
                             schedulerDetail.getCronExpression());
         } catch (org.quartz.SchedulerException e) {
             logger.error("Unable to schedule job {}", schedulerDetail.getJobName(), e);
-            throw new SchedulerException(e.getMessage());
+            throw new SchedulerException(e.getMessage(), e);
         }
     }
 
@@ -79,7 +79,7 @@ public class SchedulerServiceImpl implements SchedulerService {
             logger.info("Job {} was unregistered.", jobName);
         } catch (org.quartz.SchedulerException e) {
             logger.error("Unable to unregister job {}", jobName, e);
-            throw new SchedulerException(e.getMessage());
+            throw new SchedulerException(e.getMessage(), e);
         }
     }
 
@@ -98,7 +98,7 @@ public class SchedulerServiceImpl implements SchedulerService {
             }
         } catch (org.quartz.SchedulerException e) {
             logger.error("Unable to retrieve list of registered jobs.", e);
-            throw new SchedulerException(e.getMessage());
+            throw new SchedulerException(e.getMessage(), e);
         }
 
         final SchedulerResponseDto schedulerResponseDto = new SchedulerResponseDto(SchedulerStatus.OK);
@@ -114,7 +114,7 @@ public class SchedulerServiceImpl implements SchedulerService {
             logger.info("Job {} was resumed.", jobName);
         } catch (org.quartz.SchedulerException e) {
             logger.error("Unable to resume job {}", jobName, e);
-            throw new SchedulerException(e.getMessage());
+            throw new SchedulerException(e.getMessage(), e);
         }
     }
 
@@ -126,7 +126,7 @@ public class SchedulerServiceImpl implements SchedulerService {
             logger.info("Job {} was paused.", jobName);
         } catch (org.quartz.SchedulerException e) {
             logger.error("Unable to pause job {}", jobName, e);
-            throw new SchedulerException(e.getMessage());
+            throw new SchedulerException(e.getMessage(), e);
         }
     }
 

--- a/src/test/java/com/otilm/scheduler/service/impl/SchedulerServiceImplTest.java
+++ b/src/test/java/com/otilm/scheduler/service/impl/SchedulerServiceImplTest.java
@@ -1,5 +1,10 @@
 package com.otilm.scheduler.service.impl;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.IThrowableProxy;
+import ch.qos.logback.core.read.ListAppender;
 import com.otilm.api.exception.SchedulerException;
 import com.otilm.api.exception.ValidationException;
 import com.otilm.api.model.scheduler.SchedulerJobDto;
@@ -8,7 +13,9 @@ import com.otilm.api.model.scheduler.SchedulerResponseDto;
 import com.otilm.api.model.scheduler.SchedulerStatus;
 import com.otilm.scheduler.constants.JobConstants;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -23,9 +30,11 @@ import org.quartz.TriggerKey;
 import org.quartz.impl.JobDetailImpl;
 import org.quartz.impl.matchers.GroupMatcher;
 import org.quartz.impl.triggers.CronTriggerImpl;
+import org.slf4j.LoggerFactory;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -38,6 +47,8 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class SchedulerServiceImplTest {
 
+    private static final String CAUSE_MUST_BE_RETAINED = "the rethrown exception must retain the Quartz exception as its cause";
+
     @Mock
     private Scheduler scheduler;
 
@@ -46,6 +57,9 @@ class SchedulerServiceImplTest {
 
     private SchedulerRequestDto schedulerRequestDto;
     private SchedulerJobDto schedulerJobDto;
+
+    private Logger serviceLogger;
+    private ListAppender<ILoggingEvent> logAppender;
 
     @BeforeEach
     void setUp() {
@@ -56,6 +70,17 @@ class SchedulerServiceImplTest {
 
         schedulerRequestDto = new SchedulerRequestDto();
         schedulerRequestDto.setSchedulerJob(schedulerJobDto);
+
+        serviceLogger = (Logger) LoggerFactory.getLogger(SchedulerServiceImpl.class);
+        logAppender = new ListAppender<>();
+        logAppender.start();
+        serviceLogger.addAppender(logAppender);
+    }
+
+    @AfterEach
+    void detachLogAppender() {
+        serviceLogger.detachAppender(logAppender);
+        logAppender.stop();
     }
 
     @Test
@@ -315,5 +340,83 @@ class SchedulerServiceImplTest {
         schedulerService.disableJob("testJob");
 
         verify(scheduler).pauseJob(new JobKey("testJob", JobConstants.GROUP_NAME));
+    }
+
+    @Test
+    void createNewJobLogsTheCaughtException() throws Exception {
+        final Throwable cause = new org.quartz.SchedulerException("Scheduler error");
+        when(scheduler.checkExists(any(JobKey.class))).thenReturn(false);
+        doThrow(cause).when(scheduler).scheduleJob(any(JobDetail.class), any(Trigger.class));
+
+        final SchedulerException thrown = assertThrows(SchedulerException.class,
+                () -> schedulerService.createNewJob(schedulerRequestDto));
+
+        assertErrorLoggedWith(cause);
+        assertSame(cause, thrown.getCause(), CAUSE_MUST_BE_RETAINED);
+    }
+
+    @Test
+    void deleteJobLogsTheCaughtException() throws Exception {
+        final Throwable cause = new org.quartz.SchedulerException("Delete error");
+        doThrow(cause).when(scheduler).deleteJob(any(JobKey.class));
+
+        final SchedulerException thrown = assertThrows(SchedulerException.class,
+                () -> schedulerService.deleteJob("testJob"));
+
+        assertErrorLoggedWith(cause);
+        assertSame(cause, thrown.getCause(), CAUSE_MUST_BE_RETAINED);
+    }
+
+    @Test
+    void listJobsLogsTheCaughtException() throws Exception {
+        final Throwable cause = new org.quartz.SchedulerException("List error");
+        when(scheduler.getJobKeys(any())).thenThrow(cause);
+
+        final SchedulerException thrown = assertThrows(SchedulerException.class, () -> schedulerService.listJobs());
+
+        assertErrorLoggedWith(cause);
+        assertSame(cause, thrown.getCause(), CAUSE_MUST_BE_RETAINED);
+    }
+
+    @Test
+    void enableJobLogsTheCaughtException() throws Exception {
+        final Throwable cause = new org.quartz.SchedulerException("Resume error");
+        doThrow(cause).when(scheduler).resumeJob(any(JobKey.class));
+
+        final SchedulerException thrown = assertThrows(SchedulerException.class,
+                () -> schedulerService.enableJob("testJob"));
+
+        assertErrorLoggedWith(cause);
+        assertSame(cause, thrown.getCause(), CAUSE_MUST_BE_RETAINED);
+    }
+
+    @Test
+    void disableJobLogsTheCaughtException() throws Exception {
+        final Throwable cause = new org.quartz.SchedulerException("Pause error");
+        doThrow(cause).when(scheduler).pauseJob(any(JobKey.class));
+
+        final SchedulerException thrown = assertThrows(SchedulerException.class,
+                () -> schedulerService.disableJob("testJob"));
+
+        assertErrorLoggedWith(cause);
+        assertSame(cause, thrown.getCause(), CAUSE_MUST_BE_RETAINED);
+    }
+
+    /**
+     * Asserts that exactly one ERROR event was recorded and that it carries {@code expected} as its throwable.
+     *
+     * @param expected Exception the service was expected to hand to the logger.
+     */
+    private void assertErrorLoggedWith(Throwable expected) {
+        final List<ILoggingEvent> errors = logAppender.list
+                .stream()
+                .filter(event -> event.getLevel() == Level.ERROR)
+                .toList();
+        assertEquals(1, errors.size(), "expected exactly one ERROR event");
+
+        final IThrowableProxy thrown = errors.get(0).getThrowableProxy();
+        assertNotNull(thrown, "the caught exception must be passed to the logger, not its message");
+        assertEquals(expected.getClass().getName(), thrown.getClassName());
+        assertEquals(expected.getMessage(), thrown.getMessage());
     }
 }


### PR DESCRIPTION
Follow-up to #111, which deliberately carried only the mechanical reformat. These are the review findings that were held back from it.

## SLF4J swallowed every exception detail

Five `catch` blocks in `SchedulerServiceImpl` logged nothing useful about the failure.

Four of them passed `e.getMessage()` as a trailing argument with no `{}` to bind it:

```java
logger.error("Unable to resume job {}", jobName, e.getMessage());
```

SLF4J special-cases a trailing **`Throwable`** and renders its stack trace. A trailing **`String`** with no free placeholder is silently discarded. So the message was dropped, and the log line said only which job failed, never why.

The fifth block omitted the exception outright.

All five now pass `e` itself, so the stack trace reaches the log at the point of failure.

## Two garbled log messages

| Before | After |
|---|---|
| `Scheduling new job withe name {}` | `Scheduling new job with name {}` |
| `Job {} scheduled with by {}` | `Job {} scheduled with CRON expression {}` |

## SonarQube

**`java:S6204`** — `ExceptionHandlingAdvice.java:72`, `collect(Collectors.toList())` → `.toList()`. Sonar's caveat is that `Stream.toList()` is immutable; this value is an `@ExceptionHandler` return that Jackson serialises and nothing mutates. The `Collectors` import went with it, which Checkstyle's `UnusedImports` would otherwise have flagged.

**`java:S4488`** — `SchedulerController.java:20`, `@RequestMapping(method = RequestMethod.POST)` → `@PostMapping`. Identical mapping. The class-level `@RequestMapping("/v1/scheduler")` stays.

## Verification

`mvn verify` — 70 tests pass, Spotless clean, 0 Checkstyle violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
