### PR TITLE
Break enum constants one per line

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -27,7 +27,9 @@ ij_java_names_count_to_use_import_on_demand = 999
 ij_java_imports_layout = *,|,$*
 
 # Javadoc. Eclipse puts a single space before a tag description and never pads to
-# align, nor adds <p> to empty lines.
+# align, nor adds <p> to empty lines, and it leaves a one-line /** ... */ alone
+# instead of exploding it to three.
+ij_java_doc_do_not_wrap_if_one_line = true
 ij_java_doc_align_param_comments = false
 ij_java_doc_align_exception_comments = false
 ij_java_doc_add_p_tag_on_empty_lines = false
@@ -69,6 +71,10 @@ ij_java_extends_list_wrap = normal
 # One call per line, but only for a chain that does not fit. Mirrors Eclipse's
 # alignment_for_selector_in_method_invocation=48.
 ij_java_method_call_chain_wrap = on_every_item
+# Every enum constant on its own line, even when several would fit. Mirrors Eclipse's
+# alignment_for_enum_constants=49: split_into_lines is IntelliJ's "wrap always" (=2), while
+# on_every_item — despite the name — is "chop down if long" (=5) and drops the force bit.
+ij_java_enum_constants_wrap = split_into_lines
 
 # Eclipse indents every continuation by a flat 8 spaces; IntelliJ aligns to the
 # opening delimiter instead. Continuation alignment is the single largest source of

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -5,3 +5,6 @@
 
 # Apply Spotless formatting, brace and wildcard-import cleanup
 f4d75a9114c9dafc83d1e0214ca6e484f06c41da
+
+# Break enum constants one per line
+93f5cbf5560fd7f1fb8491cba3005ffdfb73f4b3

--- a/src/main/java/com/otilm/scheduler/messaging/configuration/MessagingProperties.java
+++ b/src/main/java/com/otilm/scheduler/messaging/configuration/MessagingProperties.java
@@ -113,6 +113,7 @@ public record MessagingProperties(@NotNull MessagingProperties.BrokerType broker
     }
 
     public enum BrokerType {
-        RABBITMQ, SERVICEBUS
+        RABBITMQ,
+        SERVICEBUS
     }
 }


### PR DESCRIPTION
> Parent change [OmniTrustILM/dependencies#146](https://github.com/OmniTrustILM/dependencies/pull/146) is merged and `build-tools:1.4.3-SNAPSHOT` republished (`1.4.3-20260811.134904-4`), so CI here is green against the new profile.

## What

Reformat under the parent's new `alignment_for_enum_constants=49`, and add the matching `.editorconfig` line.

Scheduler has only one packed constant list, `BrokerType`, so the reformat is small here:

```diff
     public enum BrokerType {
-        RABBITMQ, SERVICEBUS
+        RABBITMQ,
+        SERVICEBUS
     }
```

The `.editorconfig` half still matters: without it the IDE rejoins any enum a future change touches, and the Spotless gate then fails on push.

## Also: one-line Javadoc

The `.editorconfig` picks up `ij_java_doc_do_not_wrap_if_one_line = true`, which stops IntelliJ exploding a one-line `/** ... */` into three on every reformat. That was pure diff churn rather than a gate failure — Eclipse preserves either form, so Spotless calls both clean and never corrected it. No source changes result.

## Verification

- `mvn spotless:check checkstyle:check`: clean across 23 files, 0 Checkstyle violations.
- **No behaviour change**: the reformatted file verified **token-identical** to `origin/main` with a comment- and string-aware lexer.
- Commit 2 records the reformat SHA in `.git-blame-ignore-revs`, matching the convention in the sibling repos.


