### PR TITLE
Chop annotation member arrays and wrap annotation arguments

### DIFF
--- a/src/test/java/com/otilm/scheduler/service/impl/SchedulerServiceImplTest.java
+++ b/src/test/java/com/otilm/scheduler/service/impl/SchedulerServiceImplTest.java
@@ -305,7 +305,8 @@ class SchedulerServiceImplTest {
     void createNewJobWithDifferentCronExpressions() throws Exception {
         when(scheduler.checkExists(any(JobKey.class))).thenReturn(false);
 
-        String[] validCronExpressions = {"0 0 12 * * ?", // Every day at noon
+        String[] validCronExpressions = {
+                "0 0 12 * * ?", // Every day at noon
                 "0 15 10 * * ?", // 10:15 AM every day
                 "0 0/5 * * * ?", // Every 5 minutes
                 "0 0 0 1 1 ?", // Midnight on January 1st


### PR DESCRIPTION
Applies the profile change from OmniTrustILM/dependencies#147. One file, one array initialiser — scheduler has almost no annotation-heavy code, but `main` does not pass `spotless:check` under the new profile, so the gate needs it.

No `.git-blame-ignore-revs` entry: this is a two-line change, not a whole-tree reformat.

**Do not merge before OmniTrustILM/dependencies#147** — CI resolves `build-tools` from the published snapshot, so `spotless:check` will fail until that lands on `main`.